### PR TITLE
Typo fix in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <footer>
       <div class="footer">
         Made by Peggy @<a href="https://blipsandclicks.com">blipsandclicks</a>
-        during Technigo Bootcamp 2020 for educational purposes. Weather data from <a href="https://openweathermap.org/">Open Weather</a>.
+        during Technigo Bootcamp 2020 for educational purposes. Weather data from <a href="https://openweathermap.org/">OpenWeather</a>.
       </div>
     </footer>
   </section>


### PR DESCRIPTION
- tiny push to remove space in name of API source to make OpenWeather one word.